### PR TITLE
add license title, adjust copyright notice

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,6 @@
-Copyright (c) 2015, Mapbox <tom@mapbox.com>
+ISC License
+
+Copyright (c) 2015, Tom MacWright <tom@macwright.org>
 
 Permission to use, copy, modify, and/or distribute this software for any
 purpose with or without fee is hereby granted, provided that the above


### PR DESCRIPTION
I took the liberty to change the copyright notice to match the license in your other repos, since you added `tom@mapbox.com` (rather than a generic Mapbox email) as the email address.

I can revert that change if it is incorrect.